### PR TITLE
Tighten up margins on card titles

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -223,16 +223,13 @@ body {
 
   p {
     word-break: break-word;
+    margin-block-start: 0.5em;
+    margin-block-end: 0.5em;
   }
 }
 
 .card-header {
   display: flex;
-  
-  p {
-    margin-block-start: 0.5em;
-    margin-block-end: 0.5em;
-  }
 }
 
 .issue-number-container {


### PR DESCRIPTION
Don't take up quite so much vertical space per card.

I have no idea if this is valid SCSS or even fixes the problem.