### PR TITLE
Fix Drag 'n Drop for PRs

### DIFF
--- a/src/components/Board.js
+++ b/src/components/Board.js
@@ -22,6 +22,7 @@ export default function Board( { member, statusLabels }) {
             queryString={queryString}
             statusLabelId={statusLabel ? statusLabel.id : null}
             allQueryStrings={allQueryStrings}
+            allStatusLabels={statusLabels}
           />
         );
       })}

--- a/src/components/Card.js
+++ b/src/components/Card.js
@@ -5,13 +5,12 @@ import '../App.scss';
 
 export default function Card({ issue, originStatusLabelId }) {
 
-  const onDragStart = (issueId, originStatusLabelId, labelIds) => (e) => {
-    const data = JSON.stringify({ issueId, originStatusLabelId, labelIds });
+  const onDragStart = (originStatusLabelId, number, labels, url) => (e) => {
+    const data = JSON.stringify({ originStatusLabelId, number, labels, url });
     e.dataTransfer.setData("text/plain", data);
   }
 
   const {
-    id,
     number,
     url,
     title,
@@ -20,10 +19,8 @@ export default function Card({ issue, originStatusLabelId }) {
   } = issue;
   const isPR = url.includes("pull");
 
-  const labelIds = labels.map((label) => label.id);
-
   return (
-    <div className="card" draggable onDragStart={onDragStart(id, originStatusLabelId, labelIds)}  >
+    <div className="card" draggable onDragStart={onDragStart(originStatusLabelId, number, labels, url)}  >
       <div className="card-container">
         <div className="card-header">
           <h4 className="issue-number-container">

--- a/src/helpers/github.js
+++ b/src/helpers/github.js
@@ -165,9 +165,9 @@ export const GET_BUCKET = gql`
   }
 `
 
-export const UPDATE_PR = gql`
-  mutation updatePullRequest($owner: String!, $repo: String!, $issue: String!, $state: String!, $labels: [String!]) {
-    updatePullRequest(input:{state:$state, labels:$labels}, owner:$owner, repo:$repo, issue:$issue)
+export const UPDATE_GITHUB_ISSUE = gql`
+  mutation updateIssue($owner: String!, $repo: String!, $issue: String!, $state: String!, $labels: [String!]) {
+    updateIssue(input:{state:$state, labels:$labels}, owner:$owner, repo:$repo, issue:$issue)
       @rest(
         type:"PullRequest"
         path:"/repos/{args.owner}/{args.repo}/issues/{args.issue}"
@@ -175,6 +175,10 @@ export const UPDATE_PR = gql`
       ) {
         node_id
         labels
+        number
+        title
+        html_url
+        assignees
       }
   }
 `;
@@ -261,4 +265,28 @@ export function getQueryString(member, bucket) {
     `${bucketLabels} ${CONFIG.queries.meetings[member].labels}` :
     bucketLabels;
   return queryStringBuilder(view, member, labels, state);
+}
+
+export function updateIssueInCache(updatedIssue) {
+  return {
+    id: updatedIssue.node_id,
+    number: updatedIssue.number,
+    title: updatedIssue.title,
+    url: updatedIssue.html_url,
+    assignees: { edges: updatedIssue.assignees.map((assignee) => (
+      {
+        node: {
+          login: assignee.login,
+          avatarUrl: assignee.avatar_url
+         }
+      }
+    ))},
+    labels: {
+      nodes: updatedIssue.labels.map((label) => (
+        {
+          color: label.color,
+          id: label.node_id, name: label.name
+        }))
+    }
+  };
 }

--- a/src/helpers/ui.js
+++ b/src/helpers/ui.js
@@ -1,3 +1,5 @@
+import { CONFIG } from "./github";
+
 function getSearchParams() {
   return new URLSearchParams(window.location.search);
 }
@@ -44,4 +46,32 @@ export const toggleSideMenu = (e) => {
 export function toggleDisplay(title) {
   const bucket = document.getElementById(title);
   bucket.classList.toggle("js-hide");
+}
+
+export function handleOnDrop(e, statusLabelId, allStatusLabels, updateIssue) {
+  const { originStatusLabelId, number, labels, url } = JSON.parse(e.dataTransfer.getData("text/plain"));
+  if (statusLabelId === originStatusLabelId) {
+    return;
+  }
+
+  const { owner } = CONFIG;
+  const originStatusName = originStatusLabelId ? allStatusLabels.find((label) => label.id === originStatusLabelId).name : null;
+  const updatedLabelNames = labels
+    .filter((label) => label.name !== originStatusName)
+    .map((label) => label.name);
+
+  const getRepoName = (url) => {
+    const parts = url.split("/")
+    const ownerIndex = parts.findIndex((part) => part === owner);
+    return parts[ownerIndex + 1];
+  };
+
+  const repo = getRepoName(url);
+  // Moving card into Closed bucket
+  if (!statusLabelId) {
+    updateIssue({ variables: { owner, repo, issue: number, labels: updatedLabelNames, state: "closed" }});
+  } else {
+    updatedLabelNames.push(allStatusLabels.find((label) => label.id === statusLabelId).name);
+    updateIssue({ variables: { owner, repo, issue: number, labels: updatedLabelNames, state: "open" }});
+  }
 }


### PR DESCRIPTION
This PR fixes the bug that didn't allow PR issues to update status on a drag and drop. The solution was to use Github's v3 REST api. In this PR, I converted regular issue mutations to use the same new graphQL mutation as PR issues.