### PR TITLE
Fix inconsistent buckets

### DIFF
--- a/src/helpers/github.js
+++ b/src/helpers/github.js
@@ -233,7 +233,7 @@ export const CONFIG = {
       labels: {
         backlog: `-label:\"1 - Ready\" -label:\"2 - Working\" -label:\"3 - Done\" -label:\"[zube]: Ready\" -label:\"[zube]: In Progress\" -label:\"[zube]: Done\"`,
         ready: `label:\"1 - Ready\"`,
-        progress: `label:\"2 - Working\"`,
+        working: `label:\"2 - Working\"`,
         done: `label:\"3 - Done\"`,
       }
     },


### PR DESCRIPTION
In a previous change, we updated the working bucket key from "progress" to "working", but because it wasn't updated everywhere, it was causing a bug where new issues were being added to the working column despite not having that label.