### PR TITLE
Bugfix - Use githubToken instead of quadro for authToken

### DIFF
--- a/src/config/app.json
+++ b/src/config/app.json
@@ -1,5 +1,5 @@
 {
   "cookies": {
-    "authToken": "quadro"
+    "authToken": "githubToken"
   }
 }

--- a/src/helpers/authorization.js
+++ b/src/helpers/authorization.js
@@ -32,7 +32,7 @@ export function getToken() {
 
 export function logOut(e) {
   e.preventDefault();
-  deleteCookie("quadro");
+  deleteCookie("githubToken");
   fetch("/logout")
     .then((resp) => resp.json())
     .then((resp) => {

--- a/src/helpers/authorization.js
+++ b/src/helpers/authorization.js
@@ -1,4 +1,3 @@
-import axios from "axios";
 import APP_CONFIG from "../config/app.json";
 
 const AUTH_TOKEN_KEY = APP_CONFIG.cookies.authToken;
@@ -23,19 +22,11 @@ export function getToken() {
   if (quadro != null) {
     return quadro;
   } else {
-    return axios("/authenticated")
-      .then((resp) => resp.data)
-      .then(({ token }) => {
-        if (token) {
-          setCookie(AUTH_TOKEN_KEY, token, 14);
-          return token;
-        }
-      })
-      .catch((err) => {
-        // eslint-disable-next-line no-console
-        console.log(err);
-        return null;
-      });
+    /*
+      @TODO: consider an alternative token re-fetching mechanism
+      or an error/re-login overlay message
+    */
+    throw new Error("No access token available.");
   }
 }
 


### PR DESCRIPTION
## Issue(s) being fixed / implemented:

Missing bearer token when dragging a card from one container to another

## What should be tested? (New functionality added)

Network requests for "moving" cards should succeed

1. Drag a card to another container
2. Reload page
3. Notice that the card is in the new container


Additionally, the `githubToken` cookie should be deleted upon logout

## Any known issues? (Bugs likely to be encountered while testing NOT being addressed)

The old and new containers of the dragged card do not update properly, a separate error occurs

![image](https://user-images.githubusercontent.com/51893731/215078781-40a15e5b-57ba-4404-ba09-b9a34ff32536.png)



<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>